### PR TITLE
Fixed finding the IP

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -17,6 +17,8 @@ if (interfaces) {
         }
         return ip;
       }, "");
+    } else {
+      return accum;
     }
   }, null);
 }


### PR DESCRIPTION
This code only worked if the last interface was the public IPv4 interface. If the reduce had the `accum` already, but then did another iteration, since it doesn't fall in `if (!accum)` it would return `undefined` for the `ipAddress` value.
