### PR TITLE
Example Documentation Fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ var board = new Spark({
 
 board.on("ready", function() {
   console.log("CONNECTED");
-  this.pinMode("D7", 1);
+  this.pinMode("D7", this.MODES.OUTPUT);
 
   var byte = 0;
 


### PR DESCRIPTION
Docs currently have code that doesn't work / is misleading:

1) The 'ready' event doesn't emit data, so 'CONNECTED undefined' might confuse people.
2) We're writing to D7 without setting the pinMode, so it does not blink.

Figure that ready will eventually send some data later on but better to make it correct for now.
