### PR TITLE
Fixing analog pin map handling.

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -269,8 +269,9 @@ Spark.prototype.pinMode = function(pin, mode) {
   pinInt = (pin.replace(/A|D/, "") | 0) + offset;
 
   this.pins[pinInt].mode = mode;
-
-  state.socket.write(new Buffer([ 0x00, pinInt, sMode ]));
+  var buffer = new Buffer([ 0x00, pinInt, sMode ]);
+  // console.log(buffer);
+  state.socket.write(buffer);
 
   return this;
 };
@@ -278,16 +279,19 @@ Spark.prototype.pinMode = function(pin, mode) {
 ["analogWrite", "digitalWrite"].forEach(function(fn) {
   var isAnalog = fn === "analogWrite";
   var action = isAnalog ? 0x02 : 0x01;
-  var offset = isAnalog ? 10 : 0;
+
 
   Spark.prototype[fn] = function(pin, value) {
     var state = priv.get(this);
     var buffer = new Buffer(3);
+
+    var offset = pin[0] === "A" ? 10 : 0;
     var pinInt = (pin.replace(/A|D/i, "") | 0) + offset;
 
     buffer[0] = action;
     buffer[1] = pinInt;
     buffer[2] = value;
+    // console.log(buffer);
     state.socket.write(buffer);
     this.pins[pinInt].value = value;
 
@@ -301,7 +305,7 @@ Spark.prototype.pinMode = function(pin, mode) {
   // Use 0x05 to get a continuous read.
   var action = 0x05;
   // var action = isAnalog ? 0x04 : 0x03;
-  var offset = isAnalog ? 10 : 0;
+  // var offset = isAnalog ? 10 : 0;
   var value = isAnalog ? 2 : 1;
   var type = isAnalog ? "analog" : "digital";
 
@@ -314,7 +318,7 @@ Spark.prototype.pinMode = function(pin, mode) {
     if (isAnalog && typeof pin === "number") {
       pin = "A" + pin;
     }
-
+    var offset = pin[0] === "A" ? 10 : 0;
     pinInt = (pin.replace(/A|D/i, "") | 0) + offset;
     event = type + "-read-" + pin;
 


### PR DESCRIPTION
Move offset down into the determination point for the pin, not at the global level. This allows servos to work on the PWM pins (D0, D1).
