### PR TITLE
extra check for type coercion for issue #19

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -276,7 +276,8 @@ Spark.prototype.pinMode = function(pin, mode) {
   }
 
   offset = pin[0] === "A" ? 10 : 0;
-  pinInt = (pin.replace(/A|D/, "") | 0) + offset;
+  pin = (pin && pin.replace) ? pin.replace(/A|D/, "") : pin;
+  pinInt = (pin | 0) + offset;
 
   // Throw if attempting to create a PWM or SERVO on an incapable pin
   // True PWM (3) is CONFIRMED available on:


### PR DESCRIPTION
in case pin sneaks through without being coerced into a string?

I just noticed this during a meeting, but I haven't had a chance to test this yet, please feel free to ignore this for the time being and I'll test it more thoroughly.  -- Meant to help with this thread: https://github.com/rwaldron/spark-io/issues/19#issuecomment-45295181
