### PR TITLE
Connection enhancements

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,8 @@ module.exports = function(grunt) {
           exports: true,
           document: true,
           WeakMap: true,
-          window: true
+          window: true,
+          Promise: true
         }
       },
       files: {

--- a/lib/particle.js
+++ b/lib/particle.js
@@ -331,10 +331,30 @@ Particle.prototype = Object.create(Emitter.prototype, {
   },
   LOW: {
     value: 0
+  },
+  deviceId: {
+    get: function() {
+      return priv.get(this).deviceId || "UNKNOWN";
+    } 
+  },
+  deviceName: {
+    get: function() {
+      return priv.get(this).deviceName || "UNKNOWN";
+    }
+  },
+  deviceIp: {
+    get: function() {
+      return priv.get(this).host || "UNKNOWN";
+    }
+  },
+  devicePort: {
+    get: function() {
+      return priv.get(this).port || "UNKNOWN";
+    }
   }
 });
 
-function getJson(url) {
+function fetchJson(url) {
   return new Promise(function(resolve, reject) {
     https.get(url, function(res) {
       var body = "", err;
@@ -360,10 +380,10 @@ function getJson(url) {
   });
 } 
 
-function getDeviceId(token, deviceName) {
+function fetchDeviceId(token, deviceName) {
   var url = service(token);
 
-  return getJson(url)
+  return fetchJson(url)
     .then(function(devices) {
       var device = devices.find(function(d) {
         return d.name === deviceName;
@@ -377,17 +397,17 @@ function getDeviceId(token, deviceName) {
     });
 }
 
-Particle.prototype.getEndpoint = function() {
+Particle.prototype.fetchEndpoint = function() {
   var state = priv.get(this);
   var promise = state.deviceId ? 
     Promise.resolve(state.deviceId) :
-    getDeviceId(state.token, state.deviceName).then(function(deviceId) {
+    fetchDeviceId(state.token, state.deviceName).then(function(deviceId) {
       return state.deviceId = deviceId;
     });
 
   return promise.then(function(deviceId) {
     var url = service(state.token, state.deviceId, "endpoint");
-    return getJson(url);
+    return fetchJson(url);
   });
 };
 
@@ -399,7 +419,7 @@ Particle.prototype.connect = function(handler) {
     return this;
   }
 
-  this.getEndpoint()
+  this.fetchEndpoint()
     .then(function(data) {
       if(handler) {
         handler(null, data);
@@ -790,17 +810,6 @@ Particle.prototype.close = function() {
   var state = priv.get(this);
   state.socket.close();
   state.server.close();
-};
-
-Particle.prototype.deviceInfo = function() {
-  var state = priv.get(this);
-
-  return {
-    id: state.deviceId || "UNKNOWN",
-    name: state.deviceName || "UNKNOWN",
-    ip: state.host || "UNKNOWN",
-    port: state.port || "UNKNOWN"
-  };
 };
 
 function constrain(value, lower, upper) {

--- a/lib/particle.js
+++ b/lib/particle.js
@@ -272,21 +272,27 @@ function Particle(opts) {
     }
   }.bind(this);
 
-  this.connect(function(error, data) {
-    // console.log( "connect -> connect -> handler" );
-
-    if (error !== undefined && error !== null) {
-      this.emit("error", error);
-    } else if (data.cmd !== "VarReturn") {
-      this.emit("error", errors.firmware);
-    } else {
-      var address = data.result.split(":");
-      state.host = address[0];
-      state.port = parseInt(address[1], 10);
-      // Moving into after connect so we can obtain the ip address
+  if (state.host && state.port) {
+    setTimeout(function() {
       Particle.Client.create(this, afterCreate);
-    }
-  }.bind(this));
+    }.bind(this), 0);
+  } else {
+    this.connect(function(error, data) {
+      // console.log( "connect -> connect -> handler" );
+
+      if (error !== undefined && error !== null) {
+        this.emit("error", error);
+      } else if (data.cmd !== "VarReturn") {
+        this.emit("error", errors.firmware);
+      } else {
+        var address = data.result.split(":");
+        state.host = address[0];
+        state.port = parseInt(address[1], 10);
+        // Moving into after connect so we can obtain the ip address
+        Particle.Client.create(this, afterCreate);
+      }
+    }.bind(this));
+  }
 }
 
 

--- a/lib/particle.js
+++ b/lib/particle.js
@@ -67,8 +67,20 @@ var I2C_REGISTER_NOT_SPECIFIED = 0xFF;
 var I2C_REPLY = 0x77;
 var PING_READ = 0x08;
 
-function service(deviceId) {
-  return "https://api.particle.io/v1/devices/" + deviceId + "/";
+function service(token, deviceId, action) {
+  var url = "https://api.particle.io/v1/devices";
+
+  if (deviceId) {
+    url += "/" + deviceId;
+
+    if (action) {
+      url += "/" + action;
+    }
+  }
+
+  url += "?access_token=" + token;
+
+  return url;
 }
 
 function from7BitBytes(lsb, msb) {
@@ -218,8 +230,8 @@ function Particle(opts) {
     isConnected: false,
     isReading: false,
     deviceId: opts.deviceId,
+    deviceName: opts.deviceName,
     token: opts.token,
-    service: service(opts.deviceId),
     host: opts.host || null,
     port: opts.port || 8001,
     client: null,
@@ -316,43 +328,82 @@ Particle.prototype = Object.create(Emitter.prototype, {
   }
 });
 
+function getJson(url) {
+  return new Promise(function(resolve, reject) {
+    https.get(url, function(res) {
+      var body = "", err;
+
+      res.on("data", function(d) {
+        body += d;
+      });
+      
+      res.on("end", function () {
+        if (res.statusCode === 200) {
+            var data = JSON.parse(body);
+
+            if (data.error) {
+              reject("ERROR: " + data.code + " " + data.error_description);
+            } else {
+              resolve(data);
+            }
+        } else {
+          reject(errors.cloud + ": code: " + res.statusCode + " " + res.statusMessage);
+        }
+      });
+    });
+  });
+} 
+
+function getDeviceId(token, deviceName) {
+  var url = service(token);
+
+  return getJson(url)
+    .then(function(devices) {
+      var device = devices.find(function(d) {
+        return d.name === deviceName;
+      });
+
+      if (device) {
+        return device.id;
+      } else {
+        return Promise.reject("Unable to find device " + deviceName);
+      }
+    });
+}
+
+Particle.prototype.getEndpoint = function() {
+  var state = priv.get(this);
+  var promise = state.deviceId ? 
+    Promise.resolve(state.deviceId) :
+    getDeviceId(state.token, state.deviceName).then(function(deviceId) {
+      return state.deviceId = deviceId;
+    });
+
+  return promise.then(function(deviceId) {
+    var url = service(state.token, state.deviceId, "endpoint");
+    return getJson(url);
+  });
+};
+
 Particle.prototype.connect = function(handler) {
   var state = priv.get(this);
-  var url = state.service;
-  var action = "endpoint";
-  var request;
-
+  var err;
+  
   if (state.isConnected) {
     return this;
   }
-  handler = handler.bind(this);
 
-  request = https.get(url + action + "?access_token=" + state.token, function(res) {
-    var body = "", err;
-    res.on("data", function(d) {
-      body += d;
-    });
-    res.on("end", function () {
-      if (res.statusCode === 200) {
-          var data = JSON.parse(body);
-          if (data.error) {
-            err = "ERROR: " + data.code + " " + data.error_description;
-          }
-          if (handler) {
-            handler(err, data);
-          }
-      } else {
-        err = errors.cloud + ": code: " + res.statusCode + " " + res.statusMessage;
-        if (handler) {
-          handler(new Error(err));
-        } else {
-          throw new Error(err);
-        }
+  this.getEndpoint()
+    .then(function(data) {
+      if(handler) {
+        handler(null, data);
+      }
+    })
+    .catch(function(error) {
+      if(handler) {
+        handler(error, null);
       }
     });
-  });
-
-  return this;
 };
 
 Particle.prototype.pinMode = function(pin, mode) {
@@ -733,6 +784,17 @@ Particle.prototype.close = function() {
   var state = priv.get(this);
   state.socket.close();
   state.server.close();
+};
+
+Particle.prototype.deviceInfo = function() {
+  var state = priv.get(this);
+
+  return {
+    id: state.deviceId || "UNKNOWN",
+    name: state.deviceName || "UNKNOWN",
+    ip: state.host || "UNKNOWN",
+    port: state.port || "UNKNOWN"
+  };
 };
 
 function constrain(value, lower, upper) {

--- a/readme.md
+++ b/readme.md
@@ -95,8 +95,14 @@ var byIp = new Particle({
 });
 ```
 
-**deviceInfo()**
-You can get the information that the component knows about the chip with `deviceInfo()`.  This is useful for retrieving the IP address of the Particle so that you can swith over to `host`/`port` mode if necessary.
+**device properties**
+You can get the information that the component knows about the chip with some read-only device properties.  This is useful for retrieving the IP address of the Particle so that you can swith over to `host`/`port` mode if necessary.
+
+The available properties are:
+- `deviceId`: The ID of the device
+- `deviceName`: The name of the device
+- `deviceIp`: The IP address of the device on the local network
+- `devicePort`: The port the device is listening on for connections
 
 Example:
 ```js
@@ -108,12 +114,10 @@ var board = new Particle({
 });
 
 board.on("ready", function() {
-  var device = board.deviceInfo();
-
   console.log(
-    "Connected to " + device.name + 
-    " (" + device.id + ") " +
-    "at " + device.ip + ":" + device.port
+    "Connected to " + board.deviceName + 
+    " (" + board.deviceId + ") " +
+    "at " + board.deviceIp + ":" + board.devicePort
   );
 });
 ```

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ var byId = new Particle({
 
 var byName = new Particle({
   token: process.env.PARTICLE_TOKEN,
-  deviceName: process.env.PARTICLE_DEVICE_Name || "crazy_pickle"
+  deviceName: process.env.PARTICLE_DEVICE_NAME || "crazy_pickle"
 });
 
 var byIp = new Particle({

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,51 @@ board.on("ready", function() {
 
 
 ### API
+**Constructor**
+The Particle component can be connected using one of three mechanisms: `deviceId`, `deviceName`, or `host`/`port`.  Both `deviceId` and `deviceName` require an additional `token` so that the host and port of the device can be retrieved from the Particle cloud.
+
+Example:
+```js
+var Particle = require("particle-io");
+
+var byId = new Particle({
+  token: process.env.PARTICLE_TOKEN,
+  deviceId: process.env.PARTICLE_DEVICE_ID
+});
+
+var byName = new Particle({
+  token: process.env.PARTICLE_TOKEN,
+  deviceName: process.env.PARTICLE_DEVICE_Name || "crazy_pickle"
+});
+
+var byIp = new Particle({
+  host: '192.168.0.111',
+  port: 48879
+});
+```
+
+**deviceInfo()**
+You can get the information that the component knows about the chip with `deviceInfo()`.  This is useful for retrieving the IP address of the Particle so that you can swith over to `host`/`port` mode if necessary.
+
+Example:
+```js
+var Particle = require("particle-io");
+
+var board = new Particle({
+  token: process.env.PARTICLE_TOKEN,
+  deviceName: process.env.PARTICLE_DEVICE_Name || "crazy_pickle"
+});
+
+board.on("ready", function() {
+  var device = board.deviceInfo();
+
+  console.log(
+    "Connected to " + device.name + 
+    " (" + device.id + ") " +
+    "at " + device.ip + ":" + device.port
+  );
+});
+```
 
 **MODES**
 

--- a/test/particle.js
+++ b/test/particle.js
@@ -79,6 +79,8 @@ exports["Particle"] = {
       name: "pinMode"
     }, {
       name: "servoWrite"
+    }, {
+      name: "deviceInfo"
     }];
 
     this.proto.objects = [{

--- a/test/particle.js
+++ b/test/particle.js
@@ -79,8 +79,6 @@ exports["Particle"] = {
       name: "pinMode"
     }, {
       name: "servoWrite"
-    }, {
-      name: "deviceInfo"
     }];
 
     this.proto.objects = [{
@@ -97,6 +95,14 @@ exports["Particle"] = {
       name: "pins"
     }, {
       name: "analogPins"
+    }, {
+      name: "deviceId"
+    }, {
+      name: "deviceName"
+    }, {
+      name: "deviceIp"
+    }, {
+      name: "devicePort"
     }];
 
     done();


### PR DESCRIPTION
Implements https://github.com/rwaldron/particle-io/issues/69 and https://github.com/rwaldron/particle-io/issues/67.

Gives two optional ways to connect to the Particle:

**By Name**
```js
var byName = new Particle({
  token: process.env.PARTICLE_TOKEN,
  deviceName: process.env.PARTICLE_DEVICE_NAME || "crazy_pickle"
});
```

**By Host/Port**
```js
var byIp = new Particle({
  host: '192.168.0.111',
  port: 48879
});
```

The existing mechanism (deviceId) still works:

```js
var byId = new Particle({
  token: process.env.PARTICLE_TOKEN,
  deviceId: process.env.PARTICLE_DEVICE_ID
});
```