### PR TITLE
Emit socket error events

### DIFF
--- a/lib/particle.js
+++ b/lib/particle.js
@@ -245,7 +245,6 @@ function Particle(opts) {
 
   this.name = "particle-io";
   this.buffer = [];
-  this.isReady = false;
 
   this.pins = pins.map(function(pin) {
     return {
@@ -263,18 +262,19 @@ function Particle(opts) {
   // Store private state
   priv.set(this, state);
 
-  var afterCreate = function(error) {
+  var onConnectionChange = function(error) {
     if (error) {
+      state.isConnected = false;
       this.emit("error", error);
     } else {
       state.isConnected = true;
-      this.emit("connect");
+      this.emit("ready");
     }
   }.bind(this);
 
   if (state.host && state.port) {
     setTimeout(function() {
-      Particle.Client.create(this, afterCreate);
+      Particle.Client.create(this, onConnectionChange);
     }.bind(this), 0);
   } else {
     this.connect(function(error, data) {
@@ -289,7 +289,7 @@ function Particle(opts) {
         state.host = address[0];
         state.port = parseInt(address[1], 10);
         // Moving into after connect so we can obtain the ip address
-        Particle.Client.create(this, afterCreate);
+        Particle.Client.create(this, onConnectionChange);
       }
     }.bind(this));
   }
@@ -297,7 +297,7 @@ function Particle(opts) {
 
 
 Particle.Client = {
-  create: function(particle, afterCreate) {
+  create: function(particle, onConnectionChange) {
     if (!(particle instanceof Particle)) {
       throw new Error(errors.instance);
     }
@@ -308,14 +308,14 @@ Particle.Client = {
     };
 
     state.socket = net.connect(connection, function() {
-      // Set ready state bit
-      particle.isReady = true;
-      particle.emit("ready");
-
+      onConnectionChange();
       startReading.call(particle, state);
     });
+    state.socket.on("error", function(error) {
+      onConnectionChange(error);
+    });
 
-    afterCreate();
+    particle.emit("connect");
   }
 };
 


### PR DESCRIPTION
Totally up to you whether you want to accept this, but I needed to make some of these changes so I figured I would see if you wanted them.

Reasons for the changes:
1) Net socket errors were never emitted, so if the initial connection failed, an error would be asynchronously thrown with no good way to catch it.
2) The isConnected state variable and the 'connect' event were being triggered regardless of it a connection was actually established. I left the 'connect' event that way just in case it's supposed to mean it's starting to connect
3) Deleted isReady since it didn't appear to be used anywhere